### PR TITLE
Get it working with bootsnap

### DIFF
--- a/lib/vernacular.rb
+++ b/lib/vernacular.rb
@@ -35,7 +35,8 @@ module Vernacular
       end
 
       contents = ::Vernacular.modify(contents)
-      RubyVM::InstructionSequence.compile(contents, filepath, filepath).to_binary
+      iseq = RubyVM::InstructionSequence.compile(contents, filepath, filepath)
+      iseq.to_binary
     rescue SyntaxError
       raise ::Bootsnap::CompileCache::Uncompilable, 'syntax error'
     end

--- a/lib/vernacular/source_file.rb
+++ b/lib/vernacular/source_file.rb
@@ -10,11 +10,7 @@ module Vernacular
     end
 
     def dump
-      source = File.read(source_path)
-      Vernacular.modifiers.each do |modifier|
-        source = modifier.modify(source)
-      end
-
+      source = Vernacular.modify(File.read(source_path))
       iseq = RubyVM::InstructionSequence.compile(source)
       digest = ::Digest::MD5.file(source_path).digest
       File.binwrite(iseq_path, iseq.to_binary("MD5:#{digest}"))

--- a/lib/vernacular/source_file.rb
+++ b/lib/vernacular/source_file.rb
@@ -11,7 +11,8 @@ module Vernacular
 
     def dump
       source = Vernacular.modify(File.read(source_path))
-      iseq = RubyVM::InstructionSequence.compile(source)
+      iseq = RubyVM::InstructionSequence.compile(source, source_path,
+                                                 source_path)
       digest = ::Digest::MD5.file(source_path).digest
       File.binwrite(iseq_path, iseq.to_binary("MD5:#{digest}"))
       iseq


### PR DESCRIPTION
Monkeypatch `Bootsnap::CompileCache::ISeq` in order to allow `vernacular` to work when `bootsnap` is in the stack.